### PR TITLE
Update docker with softDeps= zip

### DIFF
--- a/cloud9/Dockerfile
+++ b/cloud9/Dockerfile
@@ -22,7 +22,7 @@ ENV LC_ALL=en_US.UTF-8
 ENV LC_CTYPE=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 
-RUN buildDeps='make build-essential g++ gcc python2.7' && softDeps="tmux git" \
+RUN buildDeps='make build-essential g++ gcc python2.7' && softDeps="tmux git zip" \
  && apt-get update && apt-get upgrade -y \
  && apt-get install -y $buildDeps $softDeps --no-install-recommends \
  && npm install -g forever && npm cache clean --force \


### PR DESCRIPTION
With this added feature you're able to download complete workspace folders as .zip file.  Currently you will get a 501 error due to zip is not added to the container.